### PR TITLE
fix: add vendor prefixing to `-webkit-align-items`

### DIFF
--- a/src/styles/components/button.styl
+++ b/src/styles/components/button.styl
@@ -1,6 +1,7 @@
 .zi-btn
   -webkit-box-align center
   -webkit-align-items center
+  align-items center
   display inline-block
   padding: 0 1.375rem
   border-radius var(--geist-radius)


### PR DESCRIPTION
## PR Checklist

- [X] Fix linting errors

Solves #48 

## Change information

Just added `align-items` property.

