### PR TITLE
fix: add link to geist react

### DIFF
--- a/src/templates/summary.pug
+++ b/src/templates/summary.pug
@@ -6,7 +6,7 @@ p Geist style is a modern Css library,
   | Of course if you are interested please see the following related projects:
 ul
   li
-    a Geist React (React components)
+    a(href="https://github.com/geist-org/react") Geist React (React components)
   li
     a(href="https://github.com/geist-org/typography") Geist Typography (smaller text styles)
 


### PR DESCRIPTION
No Link for `geist/react`

So added it. 

<img width="839" alt="Screenshot 2021-03-08 at 5 19 17 PM" src="https://user-images.githubusercontent.com/61158210/110317632-6c61c900-8032-11eb-920f-dcf43196748d.png">



