### PR TITLE
fix(code.styl): add zi-dark class

### DIFF
--- a/src/styles/components/code.styl
+++ b/src/styles/components/code.styl
@@ -48,3 +48,8 @@ code
 .zi-bash
   pre:before
     content '$ '
+
+.zi-dark
+  background-color var(--geist-foreground)
+  color var(--geist-background)
+  border: 1px solid var(--geist-foreground)


### PR DESCRIPTION
## PR Checklist

- [ ] Fix linting errors
- [ ] Label has been added


## Change information
Adds the `zi-dark` class which was missing, closes #63 

